### PR TITLE
metrics: add new metrics to the new endpoint

### DIFF
--- a/src/v/cloud_storage/probe.h
+++ b/src/v/cloud_storage/probe.h
@@ -131,6 +131,18 @@ public:
 
     void register_download_size(size_t n) { _cnt_bytes_received += n; }
 
+    /// Register failed transmissions
+    void failed_transmission() { _cnt_failed_tx++; }
+
+    /// Get failed transmissions
+    uint64_t get_failed_transmissions() const { return _cnt_failed_tx; }
+
+    /// Register failed recieves
+    void failed_recieve() { _cnt_failed_rx++; }
+
+    /// Get failed recieves
+    uint64_t get_failed_recieves() const { return _cnt_failed_rx; }
+
 private:
     /// Number of topic manifest uploads
     uint64_t _cnt_topic_manifest_uploads{0};
@@ -164,8 +176,13 @@ private:
     uint64_t _cnt_bytes_sent{0};
     /// Number of bytes being successfully received from S3
     uint64_t _cnt_bytes_received{0};
+    /// Number of failed requests on the transmission path
+    uint64_t _cnt_failed_tx{0};
+    /// Number of failed requests on the recieve path
+    uint64_t _cnt_failed_rx{0};
 
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -229,6 +229,7 @@ ss::future<download_result> remote::download_manifest(
         }
     }
     _probe.failed_manifest_download();
+    _probe.failed_recieve();
     if (!result) {
         vlog(
           ctxlog.warn,
@@ -300,6 +301,7 @@ ss::future<upload_result> remote::upload_manifest(
         }
     }
     _probe.failed_manifest_upload();
+    _probe.failed_transmission();
     if (!result) {
         vlog(
           ctxlog.warn,
@@ -388,6 +390,7 @@ ss::future<upload_result> remote::upload_segment(
         }
     }
     _probe.failed_upload();
+    _probe.failed_transmission();
     if (!result) {
         vlog(
           ctxlog.warn,
@@ -460,6 +463,7 @@ ss::future<download_result> remote::download_segment(
         }
     }
     _probe.failed_download();
+    _probe.failed_recieve();
     if (!result) {
         vlog(
           ctxlog.warn,

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -57,6 +57,7 @@ v_cc_library(
     partition_leaders_table.cc
     topics_frontend.cc
     controller_backend.cc
+    controller_probe.cc
     controller.cc
     partition.cc
     partition_probe.cc

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -69,7 +69,8 @@ controller::controller(
   , _security_manager(_credentials, _authorizer)
   , _data_policy_manager(data_policy_table)
   , _raft_manager(raft_manager)
-  , _cloud_storage_api(cloud_storage_api) {}
+  , _cloud_storage_api(cloud_storage_api)
+  , _probe(*this) {}
 
 ss::future<> controller::wire_up() {
     return _as.start()

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/controller_probe.h"
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
 #include "cluster/scheduling/leader_balancer.h"
@@ -114,6 +115,9 @@ public:
     ss::future<> stop();
 
 private:
+    friend controller_probe;
+
+private:
     config_manager::preload_result _config_preload;
 
     ss::sharded<ss::abort_source> _as;                     // instance per core
@@ -156,6 +160,7 @@ private:
     std::unique_ptr<leader_balancer> _leader_balancer;
     consensus_ptr _raft0;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
+    controller_probe _probe;
 };
 
 } // namespace cluster

--- a/src/v/cluster/controller_probe.cc
+++ b/src/v/cluster/controller_probe.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/controller_probe.h"
+
+#include "cluster/controller.h"
+#include "cluster/health_monitor_backend.h"
+#include "cluster/health_monitor_types.h"
+#include "cluster/members_table.h"
+#include "cluster/partition_leaders_table.h"
+#include "prometheus/prometheus_sanitize.h"
+#include "ssx/metrics.h"
+
+#include <seastar/core/metrics.hh>
+
+#include <absl/container/flat_hash_set.h>
+
+namespace cluster {
+
+controller_probe::controller_probe(controller& c) noexcept
+  : _controller(c) {
+    _controller._raft_manager.local().register_leadership_notification(
+      [this](
+        raft::group_id group,
+        model::term_id /*term*/,
+        std::optional<model::node_id> leader_id) {
+          // We are only interested in notifications regarding the controller
+          // group.
+          if (_controller._raft0->group() != group) {
+              return;
+          }
+
+          if (leader_id != _controller.self()) {
+              _public_metrics.reset();
+          } else {
+              setup_metrics();
+          }
+      });
+}
+
+void controller_probe::setup_metrics() {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    _public_metrics = std::make_unique<ss::metrics::metric_groups>(
+      ssx::public_metrics_handle);
+    _public_metrics->add_group(
+      prometheus_sanitize::metrics_name("cluster"),
+      {
+        sm::make_gauge(
+          "brokers",
+          [this] {
+              const auto& members_table
+                = _controller.get_members_table().local();
+              return members_table.all_broker_ids().size();
+          },
+          sm::description("Number of configured brokers in the cluster"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "topics",
+          [this] {
+              auto& topic_table = _controller.get_topics_state().local();
+              return topic_table.all_topics_count();
+          },
+          sm::description("Number of topics in the cluster"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "partitions",
+          [this] {
+              const auto& leaders_table
+                = _controller._partition_leaders.local();
+
+              auto partitions_count = 0;
+              leaders_table.for_each_leader(
+                [&partitions_count](auto...) { ++partitions_count; });
+
+              return partitions_count;
+          },
+          sm::description(
+            "Number of partitions in the cluster (replicas not included)"))
+          .aggregate({sm::shard_label}),
+        sm::make_gauge(
+          "unavailable_partitions",
+          [this] {
+              const auto& leaders_table
+                = _controller._partition_leaders.local();
+              auto unavailable_partitions_count = 0;
+
+              leaders_table.for_each_leader(
+                [&unavailable_partitions_count](
+                  auto /*tp_ns*/, auto /*pid*/, auto leader, auto /*term*/) {
+                    if (!leader.has_value()) {
+                        ++unavailable_partitions_count;
+                    }
+                });
+
+              return unavailable_partitions_count;
+          },
+          sm::description(
+            "Number of partitions that lack quorum among replicants"))
+          .aggregate({sm::shard_label}),
+      });
+}
+
+} // namespace cluster

--- a/src/v/cluster/controller_probe.h
+++ b/src/v/cluster/controller_probe.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "seastarx.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+namespace cluster {
+
+class controller_probe {
+public:
+    explicit controller_probe(cluster::controller&) noexcept;
+
+    void setup_metrics();
+
+private:
+    cluster::controller& _controller;
+    std::unique_ptr<ss::metrics::metric_groups> _public_metrics;
+};
+
+} // namespace cluster

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -75,6 +75,7 @@ private:
     uint64_t _bytes_produced{0};
     uint64_t _bytes_fetched{0};
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
 };
 
 partition_probe make_materialized_partition_probe();

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -503,6 +503,8 @@ std::vector<model::topic_namespace> topic_table::all_topics() const {
       [](const topic_metadata& tp) { return tp.get_configuration().tp_ns; });
 }
 
+size_t topic_table::all_topics_count() const { return _topics.size(); }
+
 std::optional<topic_metadata>
 topic_table::get_topic_metadata(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -112,6 +112,9 @@ public:
     /// Returns list of all topics that exists in the cluster.
     std::vector<model::topic_namespace> all_topics() const;
 
+    // Returns the number of topics that exist in the cluster.
+    size_t all_topics_count() const;
+
     ///\brief Returns metadata of single topic.
     ///
     /// If topic does not exists it returns an empty optional

--- a/src/v/kafka/group_probe.h
+++ b/src/v/kafka/group_probe.h
@@ -12,18 +12,26 @@
 #pragma once
 
 #include "config/configuration.h"
+#include "kafka/server/member.h"
+#include "kafka/types.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
 #include "prometheus/prometheus_sanitize.h"
+#include "ssx/metrics.h"
 
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
 #include <seastar/core/metrics.hh>
 
 namespace kafka {
 class group_offset_probe {
 public:
     explicit group_offset_probe(model::offset& offset) noexcept
-      : _offset(offset) {}
+      : _offset(offset)
+      , _public_metrics(ssx::public_metrics_handle) {}
 
     void setup_metrics(
-      const kafka::group_id& group_id, const model::topic_partition& tp) {
+      const kafka::group_id& group_id, const model::topic_partition& tp, model::topic_namespace& tp_ns) {
         namespace sm = ss::metrics;
 
         if (config::shard_local_cfg().disable_metrics()) {
@@ -44,11 +52,86 @@ public:
             [this] { return _offset; },
             sm::description("Group topic partition offset"),
             labels)});
+
+        auto ns_label = sm::label("namespace");
+        labels.push_back(ns_label(tp_ns.ns()));
+
+        _public_metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka:consumer:group"),
+          {
+            sm::make_gauge(
+            "committed_offset",
+            [this] { return _offset; },
+            sm::description("Consumer group comitted offset"),
+            labels)
+            .aggregate({sm::shard_label})
+          });
     }
 
 private:
     model::offset& _offset;
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
+};
+
+
+template <typename KeyType, typename ValType>
+class group_probe {
+  using member_map = absl::node_hash_map<kafka::member_id, member_ptr>;
+  using static_member_map = absl::node_hash_map<kafka::group_instance_id, kafka::member_id>;
+
+public:
+    explicit group_probe(member_map& members, static_member_map& static_members) noexcept
+      : _members(members)
+      , _static_members(static_members)
+      , _public_metrics(ssx::public_metrics_handle) {}
+
+    void setup_metrics(const kafka::group_id& group_id, absl::node_hash_map<KeyType,ValType>& offsets) {
+        namespace sm = ss::metrics;
+
+        if (config::shard_local_cfg().disable_metrics()) {
+            return;
+        }
+
+        auto group_label = sm::label("group");
+
+        std::vector<sm::label_instance> labels{
+          group_label(group_id())};
+
+        _public_metrics.add_group(
+          prometheus_sanitize::metrics_name("kafka:consumer:group"),
+          {
+            sm::make_gauge(
+            "consumers",
+            [this] { 
+              return _members.size() + _static_members.size();
+            },
+            sm::description("Number of consumers in a group"),
+            labels)
+            .aggregate({sm::shard_label}),
+
+            sm::make_gauge(
+            "topics",
+            [this, &offsets] {
+              // Capture list of unique topic partitions
+              // by storing them in a set
+              for (auto &elem: offsets) {
+                _topics.insert(elem.first);
+              }
+
+              return _topics.size();
+            },
+            sm::description("Number of topics in a group"),
+            labels)
+            .aggregate({sm::shard_label})
+          });
+    }
+
+private:
+    member_map& _members;
+    static_member_map& _static_members;
+    absl::node_hash_set<KeyType> _topics;
+    ss::metrics::metric_groups _public_metrics;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -255,6 +255,7 @@ connection_context::throttle_request(
                 };
                 if (track) {
                     r.method_latency = _rs.hist().auto_measure();
+                    r.public_method_latency = _rs.kafka_hist().auto_measure();
                 }
                 return r;
             });

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -352,6 +352,7 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                           })
                           .finally([self, d = std::move(d)]() mutable {
                               self->_rs.probe().service_error();
+                              self->_rs.probe().kafka_error();
                               self->_rs.probe().request_completed();
                               return std::move(d);
                           });
@@ -396,6 +397,7 @@ connection_context::dispatch_method_once(request_header hdr, size_t size) {
                               }
 
                               self->_rs.probe().service_error();
+                              self->_rs.probe().kafka_error();
                               self->_rs.conn->shutdown_input();
                           })
                           .finally([s = std::move(s), self] {});

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -154,6 +154,7 @@ private:
         ss::semaphore_units<> memlocks;
         ss::semaphore_units<> queue_units;
         std::unique_ptr<hdr_hist::measurement> method_latency;
+        std::unique_ptr<hdr_hist::measurement> public_method_latency;
         std::unique_ptr<request_tracker> tracker;
     };
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -420,6 +420,7 @@ ss::future<> group_manager::recover_partition(
                   _conf,
                   p->partition,
                   _serializer_factory(),
+                  _tp_ns,
                   _enable_group_metrics);
                 group->reset_tx_state(term);
                 _groups.emplace(group_id, group);
@@ -454,6 +455,7 @@ ss::future<> group_manager::recover_partition(
               _conf,
               p->partition,
               _serializer_factory(),
+              _tp_ns,
               _enable_group_metrics);
             group->reset_tx_state(term);
             _groups.emplace(group_id, group);
@@ -552,6 +554,7 @@ group::join_group_stages group_manager::join_group(join_group_request&& r) {
           _conf,
           p,
           _serializer_factory(),
+          _tp_ns,
           _enable_group_metrics);
         group->reset_tx_state(it->second->term);
         _groups.emplace(r.data.group_id, group);
@@ -698,6 +701,7 @@ group_manager::txn_offset_commit(txn_offset_commit_request&& r) {
                 _conf,
                 p->partition,
                 _serializer_factory(),
+                _tp_ns,
                 _enable_group_metrics);
               group->reset_tx_state(p->term);
               _groups.emplace(r.data.group_id, group);
@@ -782,6 +786,7 @@ group_manager::begin_tx(cluster::begin_group_tx_request&& r) {
                 _conf,
                 p->partition,
                 _serializer_factory(),
+                _tp_ns,
                 _enable_group_metrics);
               group->reset_tx_state(p->term);
               _groups.emplace(r.group_id, group);
@@ -888,6 +893,7 @@ group_manager::offset_commit(offset_commit_request&& r) {
               _conf,
               p->partition,
               _serializer_factory(),
+              _tp_ns,
               _enable_group_metrics);
             group->reset_tx_state(p->term);
             _groups.emplace(r.data.group_id, group);

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -51,6 +51,7 @@ static group get() {
       conf,
       nullptr,
       make_backward_compatible_serializer(),
+      model::topic_namespace{model::ns{"kafka"}, model::topic{"sample"}},
       enable_group_metrics::no);
 }
 

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -31,7 +31,8 @@ namespace net {
 
 server::server(server_configuration c)
   : cfg(std::move(c))
-  , _memory(cfg.max_service_memory_per_core) {}
+  , _memory(cfg.max_service_memory_per_core)
+  , _rpc_hist(ss::make_lw_shared<hdr_hist>()) {}
 
 server::server(ss::sharded<server_configuration>* s)
   : server(s->local()) {}

--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -126,6 +126,7 @@ public:
         server_probe& probe() { return _s->_probe; }
         ss::semaphore& memory() { return _s->_memory; }
         hdr_hist& hist() { return _s->_hist; }
+        hdr_hist& kafka_hist() { return _s->_kafka_hist; }
         ss::gate& conn_gate() { return _s->_conn_gate; }
         ss::abort_source& abort_source() { return _s->_as; }
         bool abort_requested() const { return _s->_as.abort_requested(); }
@@ -178,6 +179,8 @@ public:
 
     const server_configuration cfg; // NOLINT
     const hdr_hist& histogram() const { return _hist; }
+    ss::lw_shared_ptr<hdr_hist> rpc_hist() { return _rpc_hist; }
+    hdr_hist& kafka_hist() { return _kafka_hist; }
 
 private:
     struct listener {
@@ -200,6 +203,8 @@ private:
     ss::abort_source _as;
     ss::gate _conn_gate;
     hdr_hist _hist;
+    ss::lw_shared_ptr<hdr_hist> _rpc_hist;
+    hdr_hist _kafka_hist;
     server_probe _probe;
     ss::metrics::metric_groups _metrics;
 

--- a/src/v/net/server_probe.h
+++ b/src/v/net/server_probe.h
@@ -21,6 +21,7 @@ namespace net {
 
 class server_probe {
 public:
+    server_probe();
     void connection_established() {
         ++_connects;
         ++_connections;
@@ -52,6 +53,10 @@ public:
 
     void waiting_for_conection_rate() { ++_connections_wait_rate; }
 
+    void kafka_error() { ++_kafka_req_errors; }
+
+    void internal_error() { ++_internal_req_errors; }
+
     void setup_metrics(ss::metrics::metric_groups& mgs, const char* name);
 
 private:
@@ -69,6 +74,9 @@ private:
     uint32_t _requests_blocked_memory = 0;
     uint32_t _declined_new_connections = 0;
     uint32_t _connections_wait_rate = 0;
+    uint32_t _kafka_req_errors = 0;
+    uint32_t _internal_req_errors = 0;
+    ss::metrics::metric_groups _public_metrics;
     friend std::ostream& operator<<(std::ostream& o, const server_probe& p);
 };
 

--- a/src/v/pandaproxy/probe.cc
+++ b/src/v/pandaproxy/probe.cc
@@ -53,4 +53,50 @@ probe::probe(
          .aggregate(aggregate_labels)});
 }
 
+error_probe::error_probe(const ss::sstring& group_name)
+  : _5xx_count(0)
+  , _4xx_count(0)
+  , _3xx_count(0)
+  , _public_metrics(ssx::public_metrics_handle) {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    namespace sm = ss::metrics;
+
+    auto status_label = sm::label("status");
+
+    _public_metrics.add_group(
+      group_name,
+      {
+        sm::make_counter(
+        "request_errors_total",
+        [this] { return _5xx_count; },
+        sm::description(ssx::sformat("Total number of {} server errors", group_name)),
+        {status_label("5xx")})
+        .aggregate({sm::shard_label}),
+
+        sm::make_counter(
+        "request_errors_total",
+        [this] { return _4xx_count; },
+        sm::description(ssx::sformat("Total number of {} client errors", group_name)),
+        {status_label("4xx")})
+        .aggregate({sm::shard_label}),
+
+        sm::make_counter(
+        "request_errors_total",
+        [this] { return _3xx_count; },
+        sm::description(ssx::sformat("Total number of {} redirection errors", group_name)),
+        {status_label("3xx")})
+        .aggregate({sm::shard_label}),
+
+        sm::make_counter(
+        "request_errors_total",
+        [this] { return _5xx_count + _4xx_count + _3xx_count; },
+        sm::description(ssx::sformat("Total number of {} errors", group_name)),
+        {})
+        .aggregate({sm::shard_label})
+      });
+  }
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -20,12 +20,14 @@ namespace pandaproxy {
 
 class probe {
 public:
-    probe(ss::httpd::path_description& path_desc);
+    probe(
+      ss::httpd::path_description& path_desc, const ss::sstring& group_name);
     hdr_hist& hist() { return _request_hist; }
 
 private:
     hdr_hist _request_hist;
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
 };
 
 } // namespace pandaproxy

--- a/src/v/pandaproxy/probe.h
+++ b/src/v/pandaproxy/probe.h
@@ -30,4 +30,27 @@ private:
     ss::metrics::metric_groups _public_metrics;
 };
 
+class error_probe {
+public:
+    explicit error_probe(const ss::sstring& group_name);
+
+    void increment_5xx(int64_t count = 1) {
+        _5xx_count += count;
+    }
+
+    void increment_4xx(int64_t count = 1) {
+        _4xx_count += count;
+    }
+
+    void increment_3xx(int64_t count = 1) {
+        _3xx_count += count;
+    }
+
+private:
+    int64_t _5xx_count;
+    int64_t _4xx_count;
+    int64_t _3xx_count;
+    ss::metrics::metric_groups _public_metrics;
+};
+
 } // namespace pandaproxy

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -19,6 +19,7 @@
 #include "pandaproxy/json/types.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/parsing/exceptions.h"
+#include "pandaproxy/probe.h"
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "seastarx.h"
 
@@ -77,8 +78,28 @@ errored_body(std::error_condition ec, ss::sstring msg) {
 }
 
 inline std::unique_ptr<ss::httpd::reply>
+errored_body(std::error_condition ec, ss::sstring msg, error_probe& eprobe) {
+    auto rep = errored_body(ec, std::move(msg));
+
+    using status_type = ss::httpd::reply::status_type;
+
+    // See seastar/http/reply.hh::reply::status_type for a list
+    // of supported error status codes.
+    if (rep->_status >= status_type{500}) eprobe.increment_5xx();
+    else if (rep->_status >= status_type{400}) eprobe.increment_4xx();
+    else if (rep->_status >= status_type{300}) eprobe.increment_3xx();
+
+    return rep;
+}
+
+inline std::unique_ptr<ss::httpd::reply>
 errored_body(std::error_code ec, ss::sstring msg) {
     return errored_body(make_error_condition(ec), std::move(msg));
+}
+
+inline std::unique_ptr<ss::httpd::reply>
+errored_body(std::error_code ec, ss::sstring msg, error_probe& eprobe) {
+    return errored_body(make_error_condition(ec), std::move(msg), eprobe);
 }
 
 inline std::unique_ptr<ss::httpd::reply> unprocessable_entity(ss::sstring msg) {
@@ -87,39 +108,48 @@ inline std::unique_ptr<ss::httpd::reply> unprocessable_entity(ss::sstring msg) {
       std::move(msg));
 }
 
-inline std::unique_ptr<ss::httpd::reply> exception_reply(std::exception_ptr e) {
+inline std::unique_ptr<ss::httpd::reply> exception_reply(std::exception_ptr e, error_probe& eprobe) {
     try {
         std::rethrow_exception(e);
     } catch (const ss::gate_closed_exception& e) {
         auto eb = errored_body(
-          reply_error_code::kafka_retriable_error, e.what());
+          reply_error_code::kafka_retriable_error, e.what(), eprobe);
         set_reply_unavailable(*eb);
         return eb;
     } catch (const json::exception_base& e) {
-        return errored_body(e.error, e.what());
+        return errored_body(e.error, e.what(), eprobe);
     } catch (const parse::exception_base& e) {
-        return errored_body(e.error, e.what());
+        return errored_body(e.error, e.what(), eprobe);
     } catch (const kafka::exception_base& e) {
-        return errored_body(e.error, e.what());
+        return errored_body(e.error, e.what(), eprobe);
     } catch (const schema_registry::exception_base& e) {
-        return errored_body(e.code(), e.message());
+        return errored_body(e.code(), e.message(), eprobe);
     } catch (const seastar::httpd::base_exception& e) {
         return errored_body(
           reply_error_code::kafka_bad_request,
-          e.what()); // TODO BP: Yarr!!
+          e.what(), eprobe);
     } catch (...) {
         vlog(plog.error, "{}", std::current_exception());
+        eprobe.increment_5xx();
         throw;
     }
 }
 
-struct exception_replier {
+class exception_replier {
+public:
     ss::sstring mime_type;
+
+    exception_replier(ss::sstring mt, error_probe& eprobe)
+    : mime_type(mt)
+    , _eprobe(eprobe) {}
+
     std::unique_ptr<ss::httpd::reply> operator()(const std::exception_ptr& e) {
-        auto res = exception_reply(e);
+        auto res = exception_reply(e, _eprobe);
         res->set_mime_type(mime_type);
         return res;
     }
+private:
+    error_probe& _eprobe;
 };
 
 } // namespace pandaproxy

--- a/src/v/pandaproxy/server.cc
+++ b/src/v/pandaproxy/server.cc
@@ -126,7 +126,8 @@ server::server(
   , _pending_reqs()
   , _api20(std::move(api20))
   , _has_routes(false)
-  , _ctx(ctx) {
+  , _ctx(ctx)
+  , _eprobe(_server_name) {
     _api20.set_api_doc(_server._routes);
     _api20.register_api_file(_server._routes, header);
     _api20.add_definitions_file(_server._routes, definitions);
@@ -165,7 +166,7 @@ ss::future<> server::start(
   const std::vector<model::broker_endpoint>& advertised,
   json::serialization_format exceptional_mime_type) {
     _server._routes.register_exeption_handler(
-      exception_replier{ss::sstring{name(exceptional_mime_type)}});
+      exception_replier{ss::sstring{name(exceptional_mime_type)}, _eprobe});
     _ctx.advertised_listeners.reserve(endpoints.size());
     for (auto& server_endpoint : endpoints) {
         auto addr = co_await net::resolve_dns(server_endpoint.address);

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -96,6 +96,7 @@ public:
     ss::future<> stop();
 
 private:
+    ss::sstring _server_name;
     ss::httpd::http_server _server;
     ss::gate _pending_reqs;
     ss::api_registry_builder20 _api20;

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -14,6 +14,7 @@
 #include "config/config_store.h"
 #include "kafka/client/client.h"
 #include "pandaproxy/json/types.h"
+#include "pandaproxy/probe.h"
 #include "seastarx.h"
 
 #include <seastar/core/abort_source.hh>
@@ -102,6 +103,7 @@ private:
     ss::api_registry_builder20 _api20;
     bool _has_routes;
     context_t& _ctx;
+    error_probe _eprobe;
 };
 
 template<typename service_t>

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3132,6 +3132,10 @@ consensus::get_follower_metrics(model::node_id id) const {
       it->second);
 }
 
+size_t consensus::get_follower_count() const {
+    return is_elected_leader() ? _fstats.size() : 0;
+}
+
 ss::future<std::optional<storage::timequery_result>>
 consensus::timequery(storage::timequery_config cfg) {
     return _log.timequery(cfg).then(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -338,6 +338,7 @@ public:
 
     std::vector<follower_metrics> get_follower_metrics() const;
     result<follower_metrics> get_follower_metrics(model::node_id) const;
+    size_t get_follower_count() const;
     bool has_followers() const { return _fstats.size() > 0; }
 
     offset_monitor& visible_offset_monitor() {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -59,6 +59,7 @@
 #include "redpanda/request_auth.h"
 #include "security/scram_algorithm.h"
 #include "security/scram_authenticator.h"
+#include "ssx/metrics.h"
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
@@ -263,10 +264,20 @@ get_boolean_query_param(const ss::httpd::request& req, std::string_view name) {
 }
 
 void admin_server::configure_metrics_route() {
-    ss::prometheus::config metrics_conf;
-    metrics_conf.metric_help = "redpanda metrics";
-    metrics_conf.prefix = "vectorized";
-    ss::prometheus::add_prometheus_routes(_server, metrics_conf).get();
+    ss::prometheus::add_prometheus_routes(
+      _server,
+      {.metric_help = "redpanda metrics",
+       .prefix = "vectorized",
+       .handle = ss::metrics::impl::default_handle(),
+       .route = "/metrics"})
+      .get();
+    ss::prometheus::add_prometheus_routes(
+      _server,
+      {.metric_help = "redpanda metrics",
+       .prefix = "redpanda",
+       .handle = ssx::public_metrics_handle,
+       .route = "/public_metrics"})
+      .get();
 }
 
 ss::future<> admin_server::configure_listeners() {

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -170,6 +170,7 @@ private:
     ss::sharded<archival::upload_controller> _archival_upload_controller;
 
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics;
     std::unique_ptr<kafka::rm_group_proxy_impl> _rm_group_proxy;
     // run these first on destruction
     deferred_actions _deferred;

--- a/src/v/rpc/simple_protocol.cc
+++ b/src/v/rpc/simple_protocol.cc
@@ -200,6 +200,7 @@ simple_protocol::dispatch_method_once(header h, net::server::resources rs) {
                           "Service handler threw an exception: {}",
                           std::current_exception());
                         rs.probe().service_error();
+                        rs.probe().internal_error();
                         reply_buf.set_status(rpc::status::server_error);
                     }
                     return send_reply(ctx, std::move(reply_buf))

--- a/src/v/rpc/simple_protocol.h
+++ b/src/v/rpc/simple_protocol.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "net/server.h"
 #include "rpc/service.h"
+#include "utils/hdr_hist.h"
 
 #include <concepts>
 
@@ -34,10 +35,14 @@ public:
         }
     }
 
+    void set_rpc_hist(ss::lw_shared_ptr<hdr_hist> hist) { _rpc_hist = hist; }
+
 private:
     ss::future<> dispatch_method_once(header, net::server::resources);
 
     std::vector<std::unique_ptr<service>> _services;
+
+    ss::lw_shared_ptr<hdr_hist> _rpc_hist;
 };
 
 } // namespace rpc

--- a/src/v/ssx/CMakeLists.txt
+++ b/src/v/ssx/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
     ssx
   HDRS
     "future-util.h"
+    "metrics.h"
   DEPS
     Seastar::seastar
   )

--- a/src/v/ssx/metrics.h
+++ b/src/v/ssx/metrics.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "utils/hdr_hist.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace ssx {
+
+// The seastar metrics handle to be used for the '/public_metrics' prometheus
+// endpoint.
+const auto public_metrics_handle = seastar::metrics::default_handle() + 1;
+
+// Convert an HDR histogram to a seastar histogram for reporting.
+// Entries with values ranging form 250 microseconds to 1 minute are
+// grouped in 18 buckets of exponentially increasing size.
+inline ss::metrics::histogram report_default_histogram(const hdr_hist& hist) {
+    static constexpr size_t num_buckets = 18;
+    static constexpr size_t first_value = 250;
+    static constexpr double log_base = 2.0;
+    static constexpr int64_t scale = 1000000;
+
+    return hist.seastar_histogram_logform(
+      num_buckets, first_value, log_base, scale);
+}
+
+} // namespace ssx

--- a/src/v/utils/hdr_hist.h
+++ b/src/v/utils/hdr_hist.h
@@ -141,7 +141,11 @@ public:
     double stddev() const;
     double mean() const;
     size_t memory_size() const;
-    ss::metrics::histogram seastar_histogram_logform() const;
+    ss::metrics::histogram seastar_histogram_logform(
+      size_t num_buckets = 26,
+      int64_t first_value = 10,
+      double log_base = 2.0,
+      int64_t scale = 1) const;
 
     std::unique_ptr<measurement> auto_measure();
 


### PR DESCRIPTION
This patch adds several metrics to the new prometheus endpoint (exposed at "metrics2"). The following metrics were added:

* redpanda_kafka_consumer_group_committed_offset
  * Description: Group topic partition offset
  * Labels: group,topic,namespace,partition
  * Aggregation: shard
* redpanda_kafka_consumer_group_consumers
  * Description: Number of consumers in a consumer group
  * Labels: group
  * Aggregation: shard
* redpanda_kafka_consumer_group_topics
  * Description: Number of topics in a consumer group
  * Labels: group
  * Aggregation: shard
* redpanda_pandaproxy_request_errors_total
  * Description: Total number of request errors
  * Labels: none
  * Aggregation: shard
* redpanda_schema_registry_request_errors_total
  * Description: Total number of request errors
  * Labels: none
  * Aggregation: shard
* redpanda_shadow_indexing_errors_total
  * Description: Number of transmission & recieve errors
  * Labels: tx, rx
  * Aggregation: shard
* redpanda_rpc_request_errors_total
  * Description: Number of rpc errors
  * Labels: component
  * Aggregation: shard
* redpanda_rpc_latency_seconds
  * Description: Internal and Kafka RPC latency
  * Labels: component
  * Aggregation: shard