### PR TITLE
net: add namespaces to rpc labels

### DIFF
--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -119,7 +119,7 @@ void server_probe::setup_public_metrics(
         proto.remove_suffix(4);
     }
 
-    auto server_label = sm::label("server");
+    auto server_label = ssx::metrics::make_namespaced_label("server");
 
     mgs.add_group(
       "rpc",

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -337,7 +337,7 @@ void server::setup_public_metrics() {
         server_name.remove_suffix(4);
     }
 
-    auto server_label = sm::label("server");
+    auto server_label = ssx::metrics::make_namespaced_label("server");
 
     _public_metrics.add_group(
       prometheus_sanitize::metrics_name("rpc:request"),


### PR DESCRIPTION
## Cover letter

Add namespace to RPC labels

## UX changes

Adds namespace prefix to metric labels in our RPC code
