### PR TITLE
cloud_storage: add Azure Blob Storage Support for Tiered Storage

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -139,7 +139,10 @@ get_configurations() {
     s3conf.secret_key = cloud_roles::private_key_str("secret-key");
     s3conf.region = cloud_roles::aws_region_name("us-east-1");
     s3conf._probe = ss::make_shared(cloud_storage_clients::client_probe(
-      net::metrics_disabled::yes, net::public_metrics_disabled::yes, "", ""));
+      net::metrics_disabled::yes,
+      net::public_metrics_disabled::yes,
+      cloud_roles::aws_region_name{},
+      cloud_storage_clients::endpoint_url{}));
     s3conf.server_addr = server_addr;
 
     archival::configuration aconf;

--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -49,7 +49,8 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
 }
 
 static ss::sstring get_value_or_throw(
-  const config::property<std::optional<ss::sstring>>& prop, const char* name) {
+  const config::property<std::optional<ss::sstring>>& prop,
+  std::string_view name) {
     auto opt = prop.value();
     if (!opt) {
         vlog(
@@ -81,10 +82,12 @@ get_archival_service_config(ss::scheduling_group sg, ss::io_priority_class p) {
     auto time_limit_opt = time_limit ? std::make_optional(
                             segment_time_limit(*time_limit))
                                      : std::nullopt;
+
+    const auto& bucket_config
+      = cloud_storage::configuration::get_bucket_config();
     archival::configuration cfg{
-      .bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
-        config::shard_local_cfg().cloud_storage_bucket,
-        "cloud_storage_bucket")),
+      .bucket_name = cloud_storage_clients::bucket_name(
+        get_value_or_throw(bucket_config, bucket_config.name())),
       .cloud_storage_initial_backoff
       = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value(),
       .segment_upload_timeout

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
     NAME cloud_roles
     SRCS
+    apply_abs_credentials.cc
     apply_aws_credentials.cc
     apply_credentials.cc
     apply_gcp_credentials.cc

--- a/src/v/cloud_roles/apply_abs_credentials.cc
+++ b/src/v/cloud_roles/apply_abs_credentials.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/apply_abs_credentials.h"
+
+namespace cloud_roles {
+
+apply_abs_credentials::apply_abs_credentials(abs_credentials credentials)
+  : _signature{credentials.storage_account, credentials.shared_key} {}
+
+std::error_code
+apply_abs_credentials::add_auth(http::client::request_header& header) const {
+    return _signature.sign_header(header);
+}
+
+void apply_abs_credentials::reset_creds(credentials creds) {
+    if (!std::holds_alternative<abs_credentials>(creds)) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "credential applier reset with incorrect credential type {}",
+          creds));
+    }
+    auto abs_creds = std::get<abs_credentials>(creds);
+    _signature = signature_abs{abs_creds.storage_account, abs_creds.shared_key};
+};
+
+std::ostream& apply_abs_credentials::print(std::ostream& os) const {
+    fmt::print(os, "apply_abs_credentials");
+    return os;
+}
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/apply_abs_credentials.h
+++ b/src/v/cloud_roles/apply_abs_credentials.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/apply_credentials.h"
+#include "cloud_roles/signature.h"
+
+namespace cloud_roles {
+
+class apply_abs_credentials final : public apply_credentials::impl {
+public:
+    explicit apply_abs_credentials(abs_credentials credentials);
+
+    std::error_code
+    add_auth(http::client::request_header& header) const override;
+
+    void reset_creds(credentials creds) override;
+    std::ostream& print(std::ostream& os) const override;
+
+private:
+    signature_abs _signature;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/apply_credentials.cc
+++ b/src/v/cloud_roles/apply_credentials.cc
@@ -10,6 +10,7 @@
 
 #include "cloud_roles/apply_credentials.h"
 
+#include "cloud_roles/apply_abs_credentials.h"
 #include "cloud_roles/apply_aws_credentials.h"
 #include "cloud_roles/apply_gcp_credentials.h"
 
@@ -22,6 +23,9 @@ apply_credentials make_credentials_applier(credentials creds) {
       },
       [](gcp_credentials gc) -> std::unique_ptr<apply_credentials::impl> {
           return std::make_unique<apply_gcp_credentials>(std::move(gc));
+      },
+      [](abs_credentials abs) -> std::unique_ptr<apply_credentials::impl> {
+          return std::make_unique<apply_abs_credentials>(std::move(abs));
       })};
 }
 

--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -60,20 +60,17 @@ time_source::time_source()
 time_source::time_source(timestamp instant)
   : time_source([instant]() { return instant; }, 0) {}
 
-ss::sstring time_source::format(const char* fmt) const {
-    std::array<char, formatted_datetime_len> out_str{};
-    auto point = _gettime_fn();
-    std::time_t time = std::chrono::system_clock::to_time_t(point);
-    std::tm* gm = std::gmtime(&time);
-    auto ret = std::strftime(out_str.data(), out_str.size(), fmt, gm);
-    vassert(ret > 0, "Invalid date format string");
-    return ss::sstring(out_str.data(), ret);
+ss::sstring time_source::format_date() const {
+    return format<formatted_date_len>("%Y%m%d");
 }
 
-ss::sstring time_source::format_date() const { return format("%Y%m%d"); }
-
 ss::sstring time_source::format_datetime() const {
-    return format("%Y%m%dT%H%M%SZ");
+    return format<formatted_datetime_len>("%Y%m%dT%H%M%SZ");
+}
+
+ss::sstring time_source::format_http_datetime() const {
+    // TODO(vlad): Non english locales break this...
+    return format<http_formatted_datetime_len>("%a, %d %b %Y %H:%M:%S %Z");
 }
 
 timestamp time_source::default_source() {

--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -130,6 +130,44 @@ private:
     private_key_str _private_key;
 };
 
+class signature_abs {
+public:
+    /// \brief Initialize the ABS signature generator
+    ///
+    /// \param storage_account is the storage account to which the
+    /// request will be sent
+    /// \param shared_key is a user provided Shared Key
+    /// \param time_source is a source of timestamps for the signature
+    signature_abs(
+      storage_account storage_account,
+      private_key_str shared_key,
+      time_source c = time_source());
+
+    /// \brief Sign http header
+    /// Calculate the digest based on the header fields and add auth fields to
+    /// header.
+    ///
+    /// \param header is an in/out parameter that contains request headers
+    std::error_code sign_header(http::client::request_header& header) const;
+
+private:
+    result<ss::sstring>
+    get_string_to_sign(http::client::request_header& header) const;
+
+    result<ss::sstring> get_canonicalized_resource(
+      const http::client::request_header& header) const;
+
+    ss::sstring
+    get_canonicalized_headers(const http::client::request_header& header) const;
+
+    /// Time of the signing key
+    time_source _sig_time;
+    /// Name of the storage account in use
+    storage_account _storage_account;
+    /// Shared key
+    private_key_str _shared_key;
+};
+
 template<class Fn>
 time_source::time_source(Fn&& fn, int)
   : _gettime_fn(std::forward<Fn>(fn)) {}

--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -24,13 +24,13 @@
 namespace cloud_roles {
 
 /// \brief Internal s3 client error code
-enum class s3_client_error_code : int {
+enum class signing_error_code : int {
     invalid_uri,
     invalid_uri_params,
     not_enough_arguments,
 };
 
-std::error_code make_error_code(s3_client_error_code ec) noexcept;
+std::error_code make_error_code(signing_error_code ec) noexcept;
 
 /// Time source for signature_v4 and signature_abs. Supports
 /// two formats: ISO8601 and RFC9110.

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -94,9 +94,15 @@ struct aws_credentials {
     aws_region_name region;
 };
 
+struct abs_credentials {
+    storage_account storage_account;
+    private_key_str shared_key;
+};
+
 std::ostream& operator<<(std::ostream& os, const aws_credentials& ac);
 
-using credentials = std::variant<aws_credentials, gcp_credentials>;
+using credentials
+  = std::variant<aws_credentials, gcp_credentials, abs_credentials>;
 
 std::ostream& operator<<(std::ostream& os, const credentials& c);
 

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -85,6 +85,7 @@ using public_key_str = named_type<ss::sstring, struct s3_public_key_str>;
 using private_key_str = named_type<ss::sstring, struct s3_private_key_str>;
 using timestamp = std::chrono::time_point<std::chrono::system_clock>;
 using s3_session_token = named_type<ss::sstring, struct s3_session_token_str>;
+using storage_account = named_type<ss::sstring, struct storage_account_tag>;
 
 struct aws_credentials {
     public_key_str access_key_id;

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -680,6 +680,12 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
                                   cloud_storage_clients::s3_configuration,
                                   cfg_type>) {
                       return cloud_roles::aws_region_name{cfg.region};
+                  } else if constexpr (std::is_same_v<
+                                         cloud_storage_clients::
+                                           abs_configuration,
+                                         cfg_type>) {
+                      vassert(false, "Attempt to create refresh creds for ABS");
+                      return cloud_roles::aws_region_name{};
                   } else {
                       static_assert(
                         cloud_storage_clients::always_false_v<cfg_type>,
@@ -718,7 +724,7 @@ bool auth_refresh_bg_op::is_static_config() const {
 
 cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
     return std::visit(
-      [](const auto& cfg) {
+      [](const auto& cfg) -> cloud_roles::credentials {
           using cfg_type = std::decay_t<decltype(cfg)>;
           if constexpr (std::is_same_v<
                           cloud_storage_clients::s3_configuration,
@@ -728,6 +734,11 @@ cloud_roles::credentials auth_refresh_bg_op::build_static_credentials() const {
                 cfg.secret_key.value(),
                 std::nullopt,
                 cfg.region};
+          } else if constexpr (std::is_same_v<
+                                 cloud_storage_clients::abs_configuration,
+                                 cfg_type>) {
+              return cloud_roles::abs_credentials{
+                cfg.storage_account_name, cfg.shared_key.value()};
           } else {
               static_assert(
                 cloud_storage_clients::always_false_v<cfg_type>,

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -48,8 +48,8 @@ s3_imposter_fixture::get_configuration() {
     conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,
       net::public_metrics_disabled::yes,
-      "us-east-1",
-      httpd_host_name);
+      cloud_roles::aws_region_name{"us-east-1"},
+      cloud_storage_clients::endpoint_url{httpd_host_name});
     return conf;
 }
 

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -11,8 +11,31 @@
 #include "cloud_storage/types.h"
 
 #include "cloud_storage/logger.h"
-#include "config/configuration.h"
 #include "vlog.h"
+
+namespace {
+cloud_storage_clients::default_overrides get_default_overrides() {
+    // Set default overrides
+    cloud_storage_clients::default_overrides overrides;
+    overrides.max_idle_time
+      = config::shard_local_cfg()
+          .cloud_storage_max_connection_idle_time_ms.value();
+    if (auto optep
+        = config::shard_local_cfg().cloud_storage_api_endpoint.value();
+        optep.has_value()) {
+        overrides.endpoint = cloud_storage_clients::endpoint_url(*optep);
+    }
+    overrides.disable_tls = config::shard_local_cfg().cloud_storage_disable_tls;
+    if (auto cert = config::shard_local_cfg().cloud_storage_trust_file.value();
+        cert.has_value()) {
+        overrides.trust_file = cloud_storage_clients::ca_trust_file(
+          std::filesystem::path(*cert));
+    }
+    overrides.port = config::shard_local_cfg().cloud_storage_api_endpoint_port;
+
+    return overrides;
+}
+} // namespace
 
 namespace cloud_storage {
 
@@ -92,7 +115,15 @@ static ss::sstring get_value_or_throw(
 }
 
 ss::future<configuration> configuration::get_config() {
-    vlog(cst_log.debug, "Generating archival configuration");
+    if (config::shard_local_cfg().cloud_storage_azure_storage_account()) {
+        co_return co_await get_abs_config();
+    } else {
+        co_return co_await get_s3_config();
+    }
+}
+
+ss::future<configuration> configuration::get_s3_config() {
+    vlog(cst_log.debug, "Generating S3 cloud storage configuration");
 
     auto cloud_credentials_source
       = config::shard_local_cfg().cloud_storage_credentials_source.value();
@@ -123,30 +154,12 @@ ss::future<configuration> configuration::get_config() {
     auto disable_public_metrics = net::public_metrics_disabled(
       config::shard_local_cfg().disable_public_metrics());
 
-    // Set default overrides
-    cloud_storage_clients::default_overrides overrides;
-    overrides.max_idle_time
-      = config::shard_local_cfg()
-          .cloud_storage_max_connection_idle_time_ms.value();
-    if (auto optep
-        = config::shard_local_cfg().cloud_storage_api_endpoint.value();
-        optep.has_value()) {
-        overrides.endpoint = cloud_storage_clients::endpoint_url(*optep);
-    }
-    overrides.disable_tls = config::shard_local_cfg().cloud_storage_disable_tls;
-    if (auto cert = config::shard_local_cfg().cloud_storage_trust_file.value();
-        cert.has_value()) {
-        overrides.trust_file = cloud_storage_clients::ca_trust_file(
-          std::filesystem::path(*cert));
-    }
-    overrides.port = config::shard_local_cfg().cloud_storage_api_endpoint_port;
-
     auto s3_conf
       = co_await cloud_storage_clients::s3_configuration::make_configuration(
         access_key,
         secret_key,
         region,
-        overrides,
+        get_default_overrides(),
         disable_metrics,
         disable_public_metrics);
 
@@ -161,8 +174,76 @@ ss::future<configuration> configuration::get_config() {
         "cloud_storage_bucket")),
       .cloud_credentials_source = cloud_credentials_source,
     };
-    vlog(cst_log.debug, "Cloud storage configuration generated: {}", cfg);
+
+    vlog(cst_log.debug, "S3 cloud storage configuration generated: {}", cfg);
     co_return cfg;
+}
+
+ss::future<configuration> configuration::get_abs_config() {
+    vlog(cst_log.debug, "Generating ABS cloud storage configuration");
+
+    const auto storage_account = cloud_roles::storage_account{
+      get_value_or_throw(
+        config::shard_local_cfg().cloud_storage_azure_storage_account,
+        "cloud_storage_azure_storage_account")};
+    const auto container = get_value_or_throw(
+      config::shard_local_cfg().cloud_storage_azure_container,
+      "cloud_storage_azure_container");
+    const auto shared_key = cloud_roles::private_key_str{get_value_or_throw(
+      config::shard_local_cfg().cloud_storage_azure_shared_key,
+      "cloud_storage_azure_shared_key")};
+
+    const auto cloud_credentials_source
+      = config::shard_local_cfg().cloud_storage_credentials_source.value();
+    if (
+      cloud_credentials_source
+      != model::cloud_credentials_source::config_file) {
+        vlog(
+          cst_log.error,
+          "Configuration property cloud_storage_credentials_source must be set "
+          "to 'config_file' as only Shared Key Authorization is supported for "
+          "now.");
+        throw std::runtime_error(
+          "configuration property cloud_storage_credentials_source is not "
+          "equal to 'config_file'");
+    }
+
+    auto disable_metrics = net::metrics_disabled(
+      config::shard_local_cfg().disable_metrics());
+    auto disable_public_metrics = net::public_metrics_disabled(
+      config::shard_local_cfg().disable_public_metrics());
+
+    auto abs_conf
+      = co_await cloud_storage_clients::abs_configuration::make_configuration(
+        shared_key,
+        storage_account,
+        get_default_overrides(),
+        disable_metrics,
+        disable_public_metrics);
+
+    configuration cfg{
+      .client_config = std::move(abs_conf),
+      .connection_limit = cloud_storage::connection_limit(
+        config::shard_local_cfg().cloud_storage_max_connections.value()),
+      .metrics_disabled = remote_metrics_disabled(
+        static_cast<bool>(disable_metrics)),
+      .bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
+        config::shard_local_cfg().cloud_storage_azure_container,
+        "cloud_storage_azure_container")),
+      .cloud_credentials_source = cloud_credentials_source,
+    };
+
+    vlog(cst_log.debug, "ABS cloud storage configuration generated: {}", cfg);
+    co_return cfg;
+}
+
+const config::property<std::optional<ss::sstring>>&
+configuration::get_bucket_config() {
+    if (config::shard_local_cfg().cloud_storage_azure_storage_account()) {
+        return config::shard_local_cfg().cloud_storage_azure_container;
+    } else {
+        return config::shard_local_cfg().cloud_storage_bucket;
+    }
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage_clients/configuration.h"
+#include "config/configuration.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -82,13 +83,13 @@ std::ostream& operator<<(std::ostream& o, const download_result& r);
 std::ostream& operator<<(std::ostream& o, const upload_result& r);
 
 struct configuration {
-    /// S3 configuration
+    /// Client configuration
     cloud_storage_clients::client_configuration client_config;
-    /// Number of simultaneous S3 uploads
+    /// Number of simultaneous client uploads
     connection_limit connection_limit;
     /// Disable metrics in the remote
     remote_metrics_disabled metrics_disabled;
-    /// The bucket to use
+    /// The S3 bucket or ABS container to use
     cloud_storage_clients::bucket_name bucket_name;
 
     model::cloud_credentials_source cloud_credentials_source;
@@ -96,6 +97,10 @@ struct configuration {
     friend std::ostream& operator<<(std::ostream& o, const configuration& cfg);
 
     static ss::future<configuration> get_config();
+    static ss::future<configuration> get_s3_config();
+    static ss::future<configuration> get_abs_config();
+    static const config::property<std::optional<ss::sstring>>&
+    get_bucket_config();
 };
 
 struct offset_range {

--- a/src/v/cloud_storage_clients/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/CMakeLists.txt
@@ -2,6 +2,7 @@
 v_cc_library(
   NAME cloud_storage_clients
   SRCS
+    abs_client.cc
     abs_error.cc
     client_pool.cc
     client_probe.cc

--- a/src/v/cloud_storage_clients/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/CMakeLists.txt
@@ -2,6 +2,7 @@
 v_cc_library(
   NAME cloud_storage_clients
   SRCS
+    abs_error.cc
     client_pool.cc
     client_probe.cc
     configuration.cc

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -1,0 +1,491 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/abs_client.h"
+
+#include "cloud_storage_clients/abs_error.h"
+#include "cloud_storage_clients/configuration.h"
+#include "cloud_storage_clients/logger.h"
+#include "cloud_storage_clients/util.h"
+#include "vlog.h"
+
+#include <utility>
+
+namespace {
+constexpr boost::beast::string_view text_plain = "text/plain";
+constexpr boost::beast::string_view block_blob = "BlockBlob";
+} // namespace
+
+namespace cloud_storage_clients {
+
+static abs_rest_error_response
+parse_rest_error_response(boost::beast::http::status result, iobuf&& buf) {
+    using namespace cloud_storage_clients;
+
+    try {
+        auto resp = util::iobuf_to_ptree(std::move(buf), abs_log);
+        auto code = resp.get<ss::sstring>("Error.Code", "");
+        auto msg = resp.get<ss::sstring>("Error.Message", "");
+        return {std::move(code), std::move(msg), result};
+    } catch (...) {
+        vlog(
+          cloud_storage_clients::abs_log.error,
+          "!!error parse error {}",
+          std::current_exception());
+        throw;
+    }
+}
+
+abs_request_creator::abs_request_creator(
+  const abs_configuration& conf,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
+  : _ap{conf.uri}
+  , _apply_credentials{std::move(apply_credentials)} {}
+
+result<http::client::request_header> abs_request_creator::make_get_blob_request(
+  bucket_name const& name, object_key const& key) {
+    // GET /{container-id}/{blob-id} HTTP/1.1
+    // Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110}
+    // x-ms-version:"2021-08-06"
+    // Authorization:{signature}
+    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::get);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+result<http::client::request_header> abs_request_creator::make_put_blob_request(
+  bucket_name const& name,
+  object_key const& key,
+  size_t payload_size_bytes,
+  const object_tag_formatter& tags) {
+    // PUT /{container-id}/{blob-id} HTTP/1.1
+    // Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110}
+    // x-ms-version:"2021-08-06"
+    // x-ms-tags:{object-formatter-tags}
+    // Authorization:{signature}
+    // Content-Length:{payload-size}
+    // Content-Type: text/plain
+    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::put);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+    header.insert(boost::beast::http::field::content_type, text_plain);
+    header.insert(
+      boost::beast::http::field::content_length,
+      std::to_string(payload_size_bytes));
+    header.insert("x-ms-blob-type", block_blob);
+
+    if (!tags.empty()) {
+        header.insert("x-ms-tags", tags.str());
+    }
+
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+result<http::client::request_header>
+abs_request_creator::make_get_blob_metadata_request(
+  bucket_name const& name, object_key const& key) {
+    // GET /{container-id}/{blob-id}?comp=metadata HTTP/1.1
+    // Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110}
+    // x-ms-version:"2021-08-06"
+    // Authorization:{signature}
+    const auto target = fmt::format(
+      "/{}/{}?comp=metadata", name(), key().string());
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::get);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+result<http::client::request_header>
+abs_request_creator::make_delete_blob_request(
+  bucket_name const& name, object_key const& key) {
+    // DELETE /{container-id}/{blob-id} HTTP/1.1
+    // Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110}
+    // x-ms-version:"2021-08-06"
+    // Authorization:{signature}
+    const auto target = fmt::format("/{}/{}", name(), key().string());
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::delete_);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+    header.insert("x-ms-delete-snapshots", "include");
+
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+result<http::client::request_header>
+abs_request_creator::make_list_blobs_request(
+  const bucket_name& name,
+  std::optional<object_key> prefix,
+  [[maybe_unused]] std::optional<object_key> start_after,
+  std::optional<size_t> max_keys) {
+    // GET /{container-id}?restype=container&comp=list&prefix={prefix}...
+    // ...&max_results{max_keys}
+    // HTTP/1.1 Host: {storage-account-id}.blob.core.windows.net
+    // x-ms-date:{req-datetime in RFC9110}
+    // x-ms-version:"2021-08-06"
+    // Authorization:{signature}
+    auto target = fmt::format("/{}?restype=container&comp=list", name());
+    if (prefix) {
+        target += fmt::format("&prefix={}", prefix.value()());
+    }
+
+    if (max_keys) {
+        target += fmt::format("&max_results={}", max_keys.value());
+    }
+
+    const boost::beast::string_view host{_ap().data(), _ap().length()};
+
+    http::client::request_header header{};
+    header.method(boost::beast::http::verb::get);
+    header.target(target);
+    header.insert(boost::beast::http::field::host, host);
+
+    auto error_code = _apply_credentials->add_auth(header);
+    if (error_code) {
+        return error_code;
+    }
+
+    return header;
+}
+
+abs_client::abs_client(
+  const abs_configuration& conf,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
+  : _requestor(conf, std::move(apply_credentials))
+  , _client(conf)
+  , _probe(conf._probe) {}
+
+abs_client::abs_client(
+  const abs_configuration& conf,
+  const ss::abort_source& as,
+  ss::lw_shared_ptr<const cloud_roles::apply_credentials> apply_credentials)
+  : _requestor(conf, std::move(apply_credentials))
+  , _client(conf, &as, conf._probe, conf.max_idle_time)
+  , _probe(conf._probe) {}
+
+ss::future<> abs_client::stop() { return _client.stop(); }
+
+void abs_client::shutdown() { _client.shutdown(); }
+
+template<typename T>
+ss::future<result<T, error_outcome>> abs_client::send_request(
+  ss::future<T> request_future,
+  const bucket_name& bucket,
+  const object_key& key) {
+    auto outcome = error_outcome::retry;
+
+    try {
+        co_return co_await std::move(request_future);
+    } catch (const abs_rest_error_response& err) {
+        _probe->register_failure(err.code());
+
+        if (err.code() == abs_error_code::blob_not_found) {
+            // Unexpected 404s are logged by 'request_future' at warn
+            // level, so only log at debug level here.
+            vlog(s3_log.debug, "BlobNotFound response received {}", key);
+            outcome = error_outcome::key_not_found;
+        } else {
+            vlog(
+              abs_log.error,
+              "Accessing storage account {}, unexpected REST API error "
+              "detected: code={}, http_code={}\n{}",
+              bucket,
+              err.code_string(),
+              err.http_code(),
+              err.message());
+            outcome = error_outcome::fail;
+        }
+    } catch (...) {
+        _probe->register_failure(abs_error_code::_unknown);
+
+        outcome = util::handle_client_transport_error(
+          std::current_exception(), abs_log);
+    }
+
+    co_return outcome;
+}
+
+ss::future<result<http::client::response_stream_ref, error_outcome>>
+abs_client::get_object(
+  bucket_name const& name,
+  object_key const& key,
+  const ss::lowres_clock::duration& timeout,
+  bool expect_no_such_key) {
+    return send_request(
+      do_get_object(name, key, timeout, expect_no_such_key), name, key);
+}
+
+ss::future<http::client::response_stream_ref> abs_client::do_get_object(
+  bucket_name const& name,
+  object_key const& key,
+  const ss::lowres_clock::duration& timeout,
+  bool expect_no_such_key) {
+    auto header = _requestor.make_get_blob_request(name, key);
+    if (!header) {
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    vlog(abs_log.trace, "send https request:\n{}", header.value());
+
+    auto response_stream = co_await _client.request(
+      std::move(header.value()), timeout);
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+
+    const auto status = response_stream->get_headers().result();
+    if (status != boost::beast::http::status::ok) {
+        if (
+          expect_no_such_key
+          && status == boost::beast::http::status::not_found) {
+            vlog(
+              abs_log.debug,
+              "ABS replied with expected error: {}",
+              response_stream->get_headers());
+        } else {
+            vlog(
+              abs_log.warn,
+              "ABS replied with error: {}",
+              response_stream->get_headers());
+        }
+
+        auto buf = co_await util::drain_response_stream(
+          std::move(response_stream));
+        throw parse_rest_error_response(status, std::move(buf));
+    }
+
+    co_return response_stream;
+}
+
+ss::future<result<abs_client::no_response, error_outcome>>
+abs_client::put_object(
+  bucket_name const& name,
+  object_key const& key,
+  size_t payload_size,
+  ss::input_stream<char>&& body,
+  const object_tag_formatter& tags,
+  const ss::lowres_clock::duration& timeout) {
+    return send_request(
+      do_put_object(name, key, payload_size, std::move(body), tags, timeout)
+        .then(
+          []() { return ss::make_ready_future<no_response>(no_response{}); }),
+      name,
+      key);
+}
+
+ss::future<> abs_client::do_put_object(
+  bucket_name const& name,
+  object_key const& key,
+  size_t payload_size,
+  ss::input_stream<char>&& body,
+  const object_tag_formatter& tags,
+  const ss::lowres_clock::duration& timeout) {
+    auto header = _requestor.make_put_blob_request(
+      name, key, payload_size, tags);
+    if (!header) {
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    auto response_stream = co_await _client.request(
+      std::move(header.value()), body, timeout);
+
+    co_await body.close();
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+
+    const auto status = response_stream->get_headers().result();
+    if (status != boost::beast::http::status::created) {
+        auto buf = co_await util::drain_response_stream(
+          std::move(response_stream));
+        throw parse_rest_error_response(status, std::move(buf));
+    }
+}
+
+ss::future<result<abs_client::head_object_result, error_outcome>>
+abs_client::head_object(
+  bucket_name const& name,
+  object_key const& key,
+  const ss::lowres_clock::duration& timeout) {
+    return send_request(do_head_object(name, key, timeout), name, key);
+}
+
+ss::future<abs_client::head_object_result> abs_client::do_head_object(
+  bucket_name const& name,
+  object_key const& key,
+  const ss::lowres_clock::duration& timeout) {
+    auto header = _requestor.make_get_blob_metadata_request(name, key);
+    if (!header) {
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    vlog(abs_log.trace, "send https request:\n{}", header.value());
+
+    auto response_stream = co_await _client.request(
+      std::move(header.value()), timeout);
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+
+    const auto status = response_stream->get_headers().result();
+    if (status == boost::beast::http::status::ok) {
+        const auto etag = response_stream->get_headers().at(
+          boost::beast::http::field::etag);
+        co_return head_object_result{
+          .object_size = 0, .etag = ss::sstring{etag.data(), etag.length()}};
+    } else {
+        auto buf = co_await util::drain_response_stream(
+          std::move(response_stream));
+        throw parse_rest_error_response(status, std::move(buf));
+    }
+}
+
+ss::future<result<abs_client::no_response, error_outcome>>
+abs_client::delete_object(
+  const bucket_name& name,
+  const object_key& key,
+  const ss::lowres_clock::duration& timeout) {
+    using ret_t = result<no_response, error_outcome>;
+    return send_request(
+             do_delete_object(name, key, timeout).then([]() {
+                 return ss::make_ready_future<no_response>(no_response{});
+             }),
+             name,
+             key)
+      .then([&name, &key](const ret_t& result) {
+          // ABS returns a 404 for attempts to delete a blob that doesn't exist.
+          // The remote doesn't expect this, so we map 404s to a successful
+          // response.
+          if (!result && result.error() == error_outcome::key_not_found) {
+              vlog(
+                abs_log.debug,
+                "Object to be deleted was not found in cloud storage: "
+                "object={}, bucket={}. Ignoring ...",
+                name,
+                key);
+              return ss::make_ready_future<ret_t>(no_response{});
+          } else {
+              return ss::make_ready_future<ret_t>(result);
+          }
+      });
+}
+
+ss::future<> abs_client::do_delete_object(
+  const bucket_name& name,
+  const object_key& key,
+  const ss::lowres_clock::duration& timeout) {
+    auto header = _requestor.make_delete_blob_request(name, key);
+    if (!header) {
+        vlog(
+          abs_log.warn, "Failed to create request header: {}", header.error());
+        throw std::system_error(header.error());
+    }
+
+    vlog(abs_log.trace, "send https request:\n{}", header.value());
+
+    auto response_stream = co_await _client.request(
+      std::move(header.value()), timeout);
+
+    co_await response_stream->prefetch_headers();
+    vassert(response_stream->is_header_done(), "Header is not received");
+
+    const auto status = response_stream->get_headers().result();
+    if (status != boost::beast::http::status::accepted) {
+        auto buf = co_await util::drain_response_stream(
+          std::move(response_stream));
+        throw parse_rest_error_response(status, std::move(buf));
+    }
+}
+
+// ss::future<result<abs_client::list_bucket_result, error_outcome>>
+// abs_client::list_objects(
+//   const bucket_name& name,
+//   std::optional<object_key> prefix,
+//   std::optional<object_key> start_after,
+//   std::optional<size_t> max_keys,
+//   const ss::lowres_clock::duration& timeout) {
+//     return send_request(
+//       do_list_objects(
+//         name, std::move(prefix), std::move(start_after), max_keys, timeout),
+//       name,
+//       object_key{""});
+// }
+//
+// ss::future<abs_client::list_bucket_result> abs_client::do_list_objects(
+//   const bucket_name& name,
+//   std::optional<object_key> prefix,
+//   std::optional<object_key> start_after,
+//   std::optional<size_t> max_keys,
+//   const ss::lowres_clock::duration& timeout) {
+//     auto header = _requestor.make_list_blobs_request(
+//       name, std::move(prefix), std::move(start_after), max_keys);
+//     if (!header) {
+//         vlog(
+//           abs_log.warn, "Failed to create request header: {}",
+//           header.error());
+//         throw std::system_error(header.error());
+//     }
+//
+//     vlog(abs_log.trace, "send https request:\n{}", header.value());
+//
+//     auto response_stream = co_await _client.request(
+//       std::move(header.value()), timeout);
+//
+//     co_await response_stream->prefetch_headers();
+//     vassert(response_stream->is_header_done(), "Header is not received");
+// }
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/apply_credentials.h"
+#include "cloud_storage_clients/client.h"
+#include "cloud_storage_clients/client_probe.h"
+#include "http/client.h"
+
+namespace cloud_storage_clients {
+
+/// Request formatter for Azure Blob Storage
+class abs_request_creator {
+public:
+    /// C-tor
+    /// \param conf is a configuration container
+    explicit abs_request_creator(
+      const abs_configuration& conf,
+      ss::lw_shared_ptr<const cloud_roles::apply_credentials>
+        apply_credentials);
+
+    /// \brief Create 'Put Blob' request header
+    ///
+    /// \param name is container name
+    /// \param key is the blob identifier
+    /// \param payload_size_bytes is a size of the object in bytes
+    /// \param payload_size_bytes is a size of the object in bytes
+    /// \param tags are formatted tags for 'x-ms-tags'
+    /// \return initialized and signed http header or error
+    result<http::client::request_header> make_put_blob_request(
+      bucket_name const& name,
+      object_key const& key,
+      size_t payload_size_bytes,
+      const object_tag_formatter& tags);
+
+    /// \brief Create a 'Get Blob' request header
+    ///
+    /// \param name is container name
+    /// \param key is the blob identifier
+    /// \return initialized and signed http header or error
+    result<http::client::request_header>
+    make_get_blob_request(bucket_name const& name, object_key const& key);
+
+    /// \brief Create a 'Get Blob Metadata' request header
+    ///
+    /// \param name is a container
+    /// \param key is a blob name
+    /// \return initialized and signed http header or error
+    result<http::client::request_header> make_get_blob_metadata_request(
+      bucket_name const& name, object_key const& key);
+
+    /// \brief Create a 'Delete Blob' request header
+    ///
+    /// \param name is a container
+    /// \param key is an blob name
+    /// \return initialized and signed http header or error
+    result<http::client::request_header>
+    make_delete_blob_request(bucket_name const& name, object_key const& key);
+
+    /// \brief Initialize http header for 'List Blobs' request
+    ///
+    /// \param name of the container
+    /// \param prefix prefix of returned blob's names
+    /// \param start_after is always ignored
+    /// \param max_keys is the max number of returned objects
+    /// \return initialized and signed http header or error
+    result<http::client::request_header> make_list_blobs_request(
+      const bucket_name& name,
+      std::optional<object_key> prefix,
+      std::optional<object_key> start_after,
+      std::optional<size_t> max_keys);
+
+private:
+    access_point_uri _ap;
+    /// Applies credentials to http requests by adding headers and signing
+    /// request payload. Shared pointer so that the credentials can be
+    /// rotated through the client pool.
+    ss::lw_shared_ptr<const cloud_roles::apply_credentials> _apply_credentials;
+};
+
+/// S3 REST-API client
+class abs_client : public client {
+public:
+    abs_client(
+      const abs_configuration& conf,
+      ss::lw_shared_ptr<const cloud_roles::apply_credentials>
+        apply_credentials);
+
+    abs_client(
+      const abs_configuration& conf,
+      const ss::abort_source& as,
+      ss::lw_shared_ptr<const cloud_roles::apply_credentials>
+        apply_credentials);
+
+    /// Stop the client
+    ss::future<> stop() override;
+
+    /// Shutdown the underlying connection
+    void shutdown() override;
+
+    /// Download object from ABS container
+    ///
+    /// \param name is a container name
+    /// \param key is a blob identifier
+    /// \param timeout is a timeout of the operation
+    /// \param expect_no_such_key log 404 as warning if set to false
+    /// \return future that becomes ready after request was sent
+    ss::future<result<http::client::response_stream_ref, error_outcome>>
+    get_object(
+      bucket_name const& name,
+      object_key const& key,
+      const ss::lowres_clock::duration& timeout,
+      bool expect_no_such_key = false) override;
+
+    /// Send Get Blob Metadata request.
+    /// \param name is a container name
+    /// \param key is an id of the blob
+    /// \param timeout is a timeout of the operation
+    /// \return future that becomes ready when the request is completed
+    ss::future<result<head_object_result, error_outcome>> head_object(
+      bucket_name const& name,
+      object_key const& key,
+      const ss::lowres_clock::duration& timeout) override;
+
+    /// Put blob to ABS container.
+    /// \param name is a container name
+    /// \param key is an id of the blob
+    /// \param payload_size is a size of the object in bytes
+    /// \param body is an input_stream that can be used to read body
+    /// \param timeout is a timeout of the operation
+    /// \return future that becomes ready when the upload is completed
+    ss::future<result<no_response, error_outcome>> put_object(
+      bucket_name const& name,
+      object_key const& key,
+      size_t payload_size,
+      ss::input_stream<char>&& body,
+      const object_tag_formatter& tags,
+      const ss::lowres_clock::duration& timeout) override;
+
+    /// Send List Blobs request
+    /// \param name is a container name
+    /// \param prefix is an optional blob prefix to match
+    /// \param start_after
+    /// \param body is an input_stream that can be used to read body
+    /// \param timeout is a timeout of the operation
+    /// \return future that becomes ready when the request is completed
+    ss::future<result<list_bucket_result, error_outcome>> list_objects(
+      const bucket_name& name,
+      std::optional<object_key> prefix = std::nullopt,
+      std::optional<object_key> start_after = std::nullopt,
+      std::optional<size_t> max_keys = std::nullopt,
+      const ss::lowres_clock::duration& timeout
+      = http::default_connect_timeout) override {
+        vassert(false, "abs_client::list_objects is not implemented");
+        co_return error_outcome::fail;
+    }
+
+    /// Send Delete Blob request
+    /// \param name is a container name
+    /// \param key is an id of the blob
+    /// \param timeout is a timeout of the operation
+    ss::future<result<no_response, error_outcome>> delete_object(
+      const bucket_name& bucket,
+      const object_key& key,
+      const ss::lowres_clock::duration& timeout) override;
+
+    ss::future<result<delete_objects_result, error_outcome>> delete_objects(
+      const bucket_name& bucket,
+      std::vector<object_key> keys,
+      ss::lowres_clock::duration timeout) override {
+        vassert(false, "abs_client::delete_objects is not implemented");
+        co_return error_outcome::fail;
+    }
+
+private:
+    template<typename T>
+    ss::future<result<T, error_outcome>> send_request(
+      ss::future<T> request_future,
+      const bucket_name& bucket,
+      const object_key& key);
+
+    ss::future<http::client::response_stream_ref> do_get_object(
+      bucket_name const& name,
+      object_key const& key,
+      const ss::lowres_clock::duration& timeout,
+      bool expect_no_such_key = false);
+
+    ss::future<> do_put_object(
+      bucket_name const& name,
+      object_key const& key,
+      size_t payload_size,
+      ss::input_stream<char>&& body,
+      const object_tag_formatter& tags,
+      const ss::lowres_clock::duration& timeout);
+
+    ss::future<head_object_result> do_head_object(
+      bucket_name const& name,
+      object_key const& key,
+      const ss::lowres_clock::duration& timeout);
+
+    ss::future<> do_delete_object(
+      const bucket_name& name,
+      const object_key& key,
+      const ss::lowres_clock::duration& timeout);
+
+    ss::future<list_bucket_result> do_list_objects(
+      const bucket_name& name,
+      std::optional<object_key> prefix,
+      std::optional<object_key> start_after,
+      std::optional<size_t> max_keys,
+      const ss::lowres_clock::duration& timeout);
+
+    abs_request_creator _requestor;
+    http::client _client;
+    ss::shared_ptr<client_probe> _probe;
+};
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/abs_error.h"
+
+#include <boost/lexical_cast.hpp>
+
+#include <map>
+
+namespace cloud_storage_clients {
+
+// NOLINTNEXTLINE
+static const std::map<ss::sstring, abs_error_code> known_aws_error_codes = {
+  {"BlobNotFound", abs_error_code::blob_not_found},
+  {"AuthenticationFailed", abs_error_code::authentication_failed},
+};
+
+std::istream& operator>>(std::istream& i, abs_error_code& code) {
+    ss::sstring c;
+    i >> c;
+    auto it = known_aws_error_codes.find(c);
+    if (it != known_aws_error_codes.end()) {
+        code = it->second;
+    } else {
+        code = abs_error_code::_unknown;
+    }
+    return i;
+}
+
+abs_rest_error_response::abs_rest_error_response(
+  ss::sstring code, ss::sstring message, boost::beast::http::status http_code)
+  : _code(boost::lexical_cast<abs_error_code>(code))
+  , _code_str(std::move(code))
+  , _message(std::move(message))
+  , _http_code(http_code) {}
+
+const char* abs_rest_error_response::what() const noexcept {
+    return _message.c_str();
+}
+
+abs_error_code abs_rest_error_response::code() const noexcept { return _code; }
+
+std::string_view abs_rest_error_response::code_string() const noexcept {
+    return _code_str;
+}
+
+std::string_view abs_rest_error_response::message() const noexcept {
+    return _message;
+}
+
+boost::beast::http::status abs_rest_error_response::http_code() const noexcept {
+    return _http_code;
+}
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/abs_error.h
+++ b/src/v/cloud_storage_clients/abs_error.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <boost/beast/http/status.hpp>
+
+#include <exception>
+
+namespace cloud_storage_clients {
+
+/// \brief Azure Blob Storage error codes
+enum class abs_error_code { blob_not_found, authentication_failed, _unknown };
+
+/// Operators to use with lexical_cast
+std::istream& operator>>(std::istream& i, abs_error_code& code);
+
+/// Error received in a response from the server
+class abs_rest_error_response : std::exception {
+public:
+    abs_rest_error_response(
+      ss::sstring code,
+      ss::sstring message,
+      boost::beast::http::status http_code);
+
+    const char* what() const noexcept override;
+
+    abs_error_code code() const noexcept;
+    std::string_view code_string() const noexcept;
+    std::string_view message() const noexcept;
+    boost::beast::http::status http_code() const noexcept;
+
+private:
+    abs_error_code _code;
+    /// Error code string representation, this string is almost always short
+    /// enough for SSA
+    ss::sstring _code_str;
+    ss::sstring _message;
+    boost::beast::http::status _http_code;
+};
+
+} // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -1,5 +1,6 @@
 #include "cloud_storage_clients/client_pool.h"
 
+#include "cloud_storage_clients/abs_client.h"
 #include "cloud_storage_clients/s3_client.h"
 
 namespace cloud_storage_clients {
@@ -87,10 +88,12 @@ void client_pool::populate_client_pool() {
 
 client_pool::http_client_ptr client_pool::make_client() const {
     return std::visit(
-      [this](const auto& cfg) {
+      [this](const auto& cfg) -> http_client_ptr {
           using cfg_type = std::decay_t<decltype(cfg)>;
           if constexpr (std::is_same_v<s3_configuration, cfg_type>) {
               return ss::make_shared<s3_client>(cfg, _as, _apply_credentials);
+          } else if constexpr (std::is_same_v<abs_configuration, cfg_type>) {
+              return ss::make_shared<abs_client>(cfg, _as, _apply_credentials);
           } else {
               static_assert(always_false_v<cfg_type>, "Unknown client type");
           }

--- a/src/v/cloud_storage_clients/client_probe.cc
+++ b/src/v/cloud_storage_clients/client_probe.cc
@@ -70,6 +70,13 @@ void client_probe::register_failure(s3_error_code err) {
     _total_rpc_errors += 1;
 }
 
+void client_probe::register_failure(abs_error_code err) {
+    if (err == abs_error_code::blob_not_found) {
+        _total_nosuchkeys += 1;
+    }
+    _total_rpc_errors += 1;
+}
+
 void client_probe::setup_internal_metrics(
   net::metrics_disabled disable, std::span<raw_label> raw_labels) {
     namespace sm = ss::metrics;

--- a/src/v/cloud_storage_clients/client_probe.h
+++ b/src/v/cloud_storage_clients/client_probe.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_roles/types.h"
+#include "cloud_storage_clients/abs_error.h"
 #include "cloud_storage_clients/s3_error.h"
 #include "cloud_storage_clients/types.h"
 #include "http/probe.h"
@@ -67,6 +68,8 @@ public:
 
     /// Register S3 rpc error
     void register_failure(s3_error_code err);
+    /// Register ABS rpc error
+    void register_failure(abs_error_code err);
 
 private:
     struct raw_label {

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -71,6 +71,22 @@ struct s3_configuration : common_configuration {
     friend std::ostream& operator<<(std::ostream& o, const s3_configuration& c);
 };
 
+struct abs_configuration : common_configuration {
+    cloud_roles::storage_account storage_account_name;
+    std::optional<cloud_roles::private_key_str> shared_key;
+
+    static ss::future<abs_configuration> make_configuration(
+      const std::optional<cloud_roles::private_key_str>& shared_key,
+      const cloud_roles::storage_account& storage_account_name,
+      const default_overrides& overrides = {},
+      net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
+      net::public_metrics_disabled disable_public_metrics
+      = net::public_metrics_disabled::yes);
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const abs_configuration& c);
+};
+
 template<typename T>
 concept storage_client_configuration
   = std::is_base_of_v<common_configuration, T>;

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -94,7 +94,8 @@ concept storage_client_configuration
 template<storage_client_configuration... Ts>
 using client_configuration_variant = std::variant<Ts...>;
 
-using client_configuration = client_configuration_variant<s3_configuration>;
+using client_configuration
+  = client_configuration_variant<abs_configuration, s3_configuration>;
 
 template<typename>
 inline constexpr bool always_false_v = false;

--- a/src/v/cloud_storage_clients/logger.h
+++ b/src/v/cloud_storage_clients/logger.h
@@ -16,4 +16,5 @@
 
 namespace cloud_storage_clients {
 inline ss::logger s3_log("s3");
+inline ss::logger abs_log("abs");
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/test_client/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/test_client/CMakeLists.txt
@@ -1,5 +1,9 @@
-# client
+# s3_client
 add_executable(s3_test_client s3_test_client_main.cc)
 target_link_libraries(s3_test_client PUBLIC v::model v::net v::http v::cloud_storage_clients v::cloud_roles)
 set_property(TARGET s3_test_client PROPERTY POSITION_INDEPENDENT_CODE ON)
 
+# abs_client
+add_executable(abs_test_client abs_test_client_main.cc)
+target_link_libraries(abs_test_client PUBLIC v::model v::net v::http v::cloud_storage_clients v::cloud_roles)
+set_property(TARGET abs_test_client PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2022 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iobuf.h"
+#include "cloud_roles/types.h"
+#include "cloud_storage_clients/abs_client.h"
+#include "http/client.h"
+#include "seastarx.h"
+#include "syschecks/syschecks.h"
+#include "utils/hdr_hist.h"
+#include "vlog.h"
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/memory.hh>
+#include <seastar/core/report_exception.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/net/dns.hh>
+#include <seastar/net/inet_address.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/net/tls.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/optional/optional.hpp>
+#include <boost/outcome/detail/value_storage.hpp>
+#include <boost/system/system_error.hpp>
+#include <gnutls/gnutls.h>
+
+#include <chrono>
+#include <exception>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+static ss::logger test_log{"test"};
+
+void cli_opts(boost::program_options::options_description_easy_init opt) {
+    namespace po = boost::program_options;
+
+    opt(
+      "blob",
+      po::value<std::vector<std::string>>()->default_value({"test.txt"}),
+      "ABS blob id");
+
+    opt(
+      "storage-account",
+      po::value<std::string>()->default_value("test-storage-account"),
+      "ABS Storage Account");
+
+    opt(
+      "container",
+      po::value<std::string>()->default_value("test-container"),
+      "ABS Container");
+
+    opt(
+      "shared-key",
+      po::value<std::string>()->default_value(""),
+      "ABS Shared Key");
+
+    opt(
+      "in",
+      po::value<std::string>()->default_value(""),
+      "file to read data for ABS blob");
+
+    opt(
+      "out",
+      po::value<std::string>()->default_value(""),
+      "file to receive data from ABS blob");
+
+    opt("delete", po::value<std::string>(), "delete object in container");
+    opt(
+      "get-metadata",
+      po::value<std::string>(),
+      "get metadata for object in container");
+
+    opt(
+      "uri", po::value<std::string>(), "alternative uri for the api endpoint");
+
+    opt("port", po::value<uint16_t>(), "alternative port for the api endpoint");
+
+    opt("disable-tls", "disable tls for this connection");
+}
+
+struct test_conf {
+    cloud_roles::storage_account storage_account;
+    cloud_storage_clients::bucket_name container;
+
+    std::vector<cloud_storage_clients::object_key> blobs;
+
+    cloud_storage_clients::abs_configuration client_cfg;
+
+    std::string in;
+    std::string out;
+
+    bool delete_blob;
+    bool get_metadata;
+};
+
+template<>
+struct fmt::formatter<test_conf> : public fmt::formatter<std::string_view> {
+    auto format(const test_conf& cfg, auto& ctx) const {
+        // make the output json-able so we can consume it in python for analysis
+        return formatter<std::string_view>::format(
+          fmt::format(
+            "[ 'storage-account': '{}', 'container': '{}', 'blobs': ['{}'] ]",
+            cfg.storage_account,
+            cfg.container,
+            fmt::join(cfg.blobs, "', '")),
+          ctx);
+    }
+};
+
+test_conf cfg_from(boost::program_options::variables_map& m) {
+    auto shared_key = cloud_roles::private_key_str(
+      m["shared-key"].as<std::string>());
+    auto storage_acc = cloud_roles::storage_account(
+      m["storage-account"].as<std::string>());
+    auto container = cloud_storage_clients::bucket_name(
+      m["container"].as<std::string>());
+    cloud_storage_clients::abs_configuration client_cfg
+      = cloud_storage_clients::abs_configuration::make_configuration(
+          shared_key,
+          storage_acc,
+          cloud_storage_clients::default_overrides{
+            .endpoint =
+              [&]() -> std::optional<cloud_storage_clients::endpoint_url> {
+                if (m.count("uri") > 0) {
+                    return cloud_storage_clients::endpoint_url{
+                      m["uri"].as<std::string>()};
+                }
+                return std::nullopt;
+            }(),
+            .port = [&]() -> std::optional<uint16_t> {
+                if (m.contains("port") > 0) {
+                    return m["port"].as<uint16_t>();
+                }
+                return std::nullopt;
+            }(),
+            .disable_tls = m.contains("disable-tls") > 0,
+          })
+          .get0();
+    vlog(test_log.info, "connecting to {}", client_cfg.server_addr);
+    return test_conf{
+      .storage_account = storage_acc,
+      .container = container,
+      .blobs =
+        [&] {
+            auto keys = m["blob"].as<std::vector<std::string>>();
+            auto out = std::vector<cloud_storage_clients::object_key>{};
+            std::transform(
+              keys.begin(),
+              keys.end(),
+              std::back_inserter(out),
+              [](auto const& ks) {
+                  return cloud_storage_clients::object_key(ks);
+              });
+            return out;
+        }(),
+      .client_cfg = std::move(client_cfg),
+      .in = m["in"].as<std::string>(),
+      .out = m["out"].as<std::string>(),
+      .delete_blob = m.count("delete") > 0,
+      .get_metadata = m.count("get-metadata") > 0,
+    };
+}
+
+// TODO(vlad): factor this out
+static std::pair<ss::input_stream<char>, uint64_t>
+get_input_file_as_stream(const std::filesystem::path& path) {
+    auto file = ss::open_file_dma(path.native(), ss::open_flags::ro).get0();
+    auto size = file.size().get0();
+    return std::make_pair(ss::make_file_input_stream(std::move(file), 0), size);
+}
+
+static ss::lw_shared_ptr<cloud_roles::apply_credentials>
+make_credentials(const cloud_storage_clients::abs_configuration& cfg) {
+    return ss::make_lw_shared(
+      cloud_roles::make_credentials_applier(cloud_roles::abs_credentials{
+        cfg.storage_account_name, cfg.shared_key.value()}));
+}
+
+static ss::output_stream<char>
+get_output_file_as_stream(const std::filesystem::path& path) {
+    auto file = ss::open_file_dma(
+                  path.native(), ss::open_flags::rw | ss::open_flags::create)
+                  .get0();
+    return ss::make_file_output_stream(std::move(file)).get0();
+}
+
+int main(int args, char** argv, char** env) {
+    syschecks::initialize_intrinsics();
+    std::setvbuf(stdout, nullptr, _IOLBF, 1024);
+    ss::app_template app;
+    cli_opts(app.add_options());
+    ss::sharded<cloud_storage_clients::abs_client> client;
+
+    return app.run(args, argv, [&] {
+        auto& cfg = app.configuration();
+        return ss::async([&] {
+            test_conf lcfg = cfg_from(cfg);
+            cloud_storage_clients::abs_configuration abs_cfg = lcfg.client_cfg;
+            vlog(test_log.info, "config:{}", lcfg);
+            vlog(test_log.info, "constructing client");
+            auto credentials_applier = make_credentials(abs_cfg);
+            client.start(abs_cfg, credentials_applier).get();
+            vlog(test_log.info, "connecting");
+            client
+              .invoke_on(
+                0,
+                [lcfg = std::move(lcfg)](
+                  cloud_storage_clients::abs_client& cli) {
+                    vlog(test_log.info, "sending request");
+                    if (!lcfg.out.empty()) {
+                        // Get Blob
+                        vlog(test_log.info, "receiving file {}", lcfg.out);
+                        auto out_file = get_output_file_as_stream(lcfg.out);
+                        const auto result = cli
+                                              .get_object(
+                                                lcfg.container,
+                                                lcfg.blobs.front(),
+                                                http::default_connect_timeout)
+                                              .get0();
+                        if (result) {
+                            auto resp = result.value()->as_input_stream();
+                            vlog(test_log.info, "response: OK");
+                            ss::copy(resp, out_file).get();
+                            vlog(test_log.info, "file write done");
+                            resp.close().get();
+                        } else {
+                            vlog(
+                              test_log.error,
+                              "GET request failed: {}",
+                              result.error());
+                        }
+                        out_file.flush().get();
+                        out_file.close().get();
+                    } else if (!lcfg.in.empty()) {
+                        // Put Blob
+                        vlog(test_log.info, "sending file {}", lcfg.in);
+                        auto [payload, payload_size] = get_input_file_as_stream(
+                          lcfg.in);
+                        const auto result = cli
+                                              .put_object(
+                                                lcfg.container,
+                                                lcfg.blobs.front(),
+                                                payload_size,
+                                                std::move(payload),
+                                                {},
+                                                http::default_connect_timeout)
+                                              .get0();
+                        if (!result) {
+                            vlog(
+                              test_log.error,
+                              "PUT request failed: {}",
+                              result.error());
+                        }
+                    } else if (lcfg.delete_blob) {
+                        // Delete Blob
+                        vlog(test_log.info, "Deleting blob");
+                        const auto result = cli
+                                              .delete_object(
+                                                lcfg.container,
+                                                lcfg.blobs.front(),
+                                                http::default_connect_timeout)
+                                              .get();
+
+                        if (result) {
+                            vlog(test_log.info, "Delete Blob completed");
+                        } else {
+                            vlog(
+                              test_log.error,
+                              "Delete request failed: {}",
+                              result.error());
+                        }
+                    } else if (lcfg.get_metadata) {
+                        // Get Blob Metadata
+                        vlog(test_log.info, "Getting blob metadata");
+                        const auto result = cli
+                                              .head_object(
+                                                lcfg.container,
+                                                lcfg.blobs.front(),
+                                                http::default_connect_timeout)
+                                              .get();
+                        if (result) {
+                            vlog(
+                              test_log.info,
+                              "Get Blob Metadata completed: etag={}",
+                              result.value().etag);
+                        } else {
+                            vlog(
+                              test_log.error,
+                              "Get Blob Metadata request failed: {}",
+                              result.error());
+                        }
+                    }
+                })
+              .get();
+            client.stop().get();
+            vlog(test_log.info, "done");
+            ss::sleep(std::chrono::seconds(1)).get();
+        });
+    });
+}

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -303,8 +303,8 @@ cloud_storage_clients::s3_configuration transport_configuration() {
     conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,
       net::public_metrics_disabled::yes,
-      "region",
-      "endpoint");
+      cloud_roles::aws_region_name{"region"},
+      cloud_storage_clients::endpoint_url{"endpoint"});
     return conf;
 }
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -103,8 +103,9 @@ partition::partition(
             stm_manager->add_stm(_archival_meta_stm);
 
             if (cloud_storage_cache.local_is_initialized()) {
-                auto bucket
-                  = config::shard_local_cfg().cloud_storage_bucket.value();
+                const auto& bucket_config
+                  = cloud_storage::configuration::get_bucket_config();
+                auto bucket = bucket_config.value();
                 if (
                   read_replica_bucket
                   && _raft->log_config().is_read_replica_mode_enabled()) {
@@ -118,8 +119,9 @@ partition::partition(
                     bucket = read_replica_bucket;
                 }
                 if (!bucket) {
-                    throw std::runtime_error{
-                      "configuration property cloud_storage_bucket is not set"};
+                    throw std::runtime_error{fmt::format(
+                      "configuration property {} is not set",
+                      bucket_config.name())};
                 }
                 _cloud_storage_partition
                   = ss::make_shared<cloud_storage::remote_partition>(

--- a/src/v/cluster/tests/archival_metadata_stm_test.cc
+++ b/src/v/cluster/tests/archival_metadata_stm_test.cc
@@ -68,8 +68,8 @@ struct archival_metadata_stm_base_fixture
         conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
           net::metrics_disabled::yes,
           net::public_metrics_disabled::yes,
-          "us-east-1",
-          ss::sstring(httpd_host_name));
+          cloud_roles::aws_region_name{"us-east-1"},
+          cloud_storage_clients::endpoint_url{httpd_host_name});
         return conf;
     }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1135,6 +1135,28 @@ configuration::configuration()
       "Enable re-uploading data for compacted topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , cloud_storage_azure_storage_account(
+      *this,
+      "cloud_storage_azure_storage_account",
+      "The name of the Azure storage account to use with Tiered Storage",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt)
+  , cloud_storage_azure_container(
+      *this,
+      "cloud_storage_azure_container",
+      "The name of the Azure container to use with Tiered Storage. Note that "
+      "the container must belong to 'cloud_storage_azure_storage_account'",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt)
+  , cloud_storage_azure_shared_key(
+      *this,
+      "cloud_storage_azure_shared_key",
+      "The shared key to be used for Azure Shared Key authentication with the "
+      "configured Azure storage account (see "
+      "'cloud_storage_azure_storage_account)'. Note that Redpanda expects this "
+      "string to be Base64 encoded.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -236,6 +236,10 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> cloud_storage_housekeeping_interval_ms;
     property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;
     property<bool> cloud_storage_enable_compacted_topic_reupload;
+    // Azure Blob Storage
+    property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;
+    property<std::optional<ss::sstring>> cloud_storage_azure_container;
+    property<std::optional<ss::sstring>> cloud_storage_azure_shared_key;
 
     // Archival upload controller
     property<std::chrono::milliseconds>


### PR DESCRIPTION
## Cover Letter

### High Level Description
This set of patches adds Azure Blob Storage support to Redpanda Tiered Storage. The implementation is pretty much complete (there's a few rough edges that I'm aware of), but I've only done a limited amount of manual testing as of 22 Dec 2022. Note that this initial implementation only supports Shared Key Authorization (more methods will be added later on).

In theory, everything that works with S3 should also be supported in ABS as all RPCs used during normal operation are implemented, but testing is pending.

### Configuration
ABS can be configured via the three cluster level configuration properties listed below. If `cloud_storage_azure_storage_account` is set, then all of them need to be set (otherwise Redpanda will refuse to start).
Note that if you wish to disable TLS for testing via `cloud_storage_disable_tls` you need to override the port via `cloud_storage_api_endpoint_port`. I'll attach an example config file to this PR.
* `cloud_storage_azure_storage_account`: the name of your storage account
* `cloud_storage_azure_container`: the name of the container
* `cloud_storage_azure_shared_key`: Shared Key provided by Azure

### Implementation Details

This PR can be split in a few high level logical stages:
1. Implementation of signing logic in `cloud_roles`
2. ABS client implementation
3. Configuration options and hooking the ABS client in

The general idea is that an instance of the `cloud_storage_clients::client_configuration` variant is created at start-up
and threaded into the relevant sharded service. It eventually reaches `cloud_storage_clients::client_pool` where it drives the type of client that's created.

The ABS client itself is designed in a similar way to the S3 client. It handles most exceptions locally and returns a recommendation to the remote on how to proceed (retry, slow down, give up, etc.).

### Follow-Ups
This PR is already pretty big, so I'd like to do the following in separate PRs.

1. Hook up the Azurite emulator into our ducktape tests and run the cloud storage tests.
2. Refine error handling. We need to figure out which errors are retry-able and how being throttled looks (e.g. ServerBusy)
3. Tweak the client interface a bit to share more code between the two clients.
<!--

See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED.

Describe, in plain language, the motivation behind the change (bug fix,
feature, improvement) in this PR and how the included commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.

  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.

  Backport of PR #PR-NUMBER

-->

## Backports Required

<!--

Checking at least one of the checkboxes is REQUIRED if this PR is not a backport.

-->

- [X] none - not a bug fix
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## UX Changes

<!--

Content in this section is OPTIONAL.

Describe, in plain language, how this PR affects an end-user. Explain
topic flags, configuration flags, command line flags, deprecation
policies, etc. that are added or modified. Don't ship user breaking
changes. Ask the @redpanda-data/product team if you need help with user
visible changes.

-->

## Release Notes

### Features
Redpanda gains support for using Azure Blob Storage with Tiered Storage. In order to point Redpanda at your ABS container, set the following new cluster configs: `cloud_storage_azure_storage_account`, `cloud_storage_azure_container`, `cloud_storage_azure_shared_key`.

### Improvements
The existing `vectorized_s3_client.*` metrics have been renamed to `vectorized_cloud_client.*` in order to match the naming on the `public_metrics` endpoint.

<!--

Adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

  ### Bug Fixes

  * Short description of the bug fix if this is a PR to `dev` branch.

  ### Features

  * Short description of the feature. Explain how to configure.

  ### Improvements

  * Short description of how this PR improves existing behavior.

If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-sction and simply list `none`, e.g.

  * none

-->
